### PR TITLE
ADDED |  First draft of health file templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+## Contributing
+
+Thanks for getting involved! Here is some information we'd like you to read and understand before you make your mark as a valued contributor.
+
+## Licensing
+
+Whenever you make a contribution to a repository containing notice of a license, you license your contribution under the same terms, and you agree that you have the right to license your contribution under those terms. If you have a separate agreement to license your contributions under different terms, such as a contributor license agreement, that agreement will supersede.
+
+By participating in this project you agree to abide by the terms of our Contributor Code of Conduct.
+
+## Submitting a pull request
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) and [clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository#about-cloning-a-repository) the repository
+2. Configure and install any required dependencies for the project
+3. Make sure any tests included in the project pass on your local machine
+4. Create a new branch: `git checkout -b my-branch-name`
+5. Make your change, add tests (where applicable), and make sure all included tests still pass
+6. Push to your fork and [submit a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/), filling in as much of the template as you can plus any other useful information that will aid in a great review
+7. Check back in now and then to see if there are any comment or questions about your pull request, and we'll get is reviewed and merged as soon as we can!
+
+A few reminders when submitting a pull request:
+
+- Follow standards for style and code quality
+- Write tests.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## What can you help with?
+
+If you'd like to contribute, but aren't sure where to start, take a look at the **open issues** in this repository for some ideas.
+
+## Reporting a security vulnerability or feedback
+
+If you discover a potential security issue in this project we ask that you notify Peak AI Security directly via email to security@peak.ai. 
+Please do **not** create a public github issue.
+
+## Useful Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)

--- a/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a bug report for peak-ai
+labels: bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**System information**
+OS, application/service release version, relevant dependency versions etc.
+
+#### Steps to reproduce the issue
+
+1.  
+2. 
+3. 
+
+
+#### What's the expected result?
+
+-
+
+
+#### What's the actual result?
+
+-
+
+
+#### Additional details / screenshot
+
+- ![Screenshot]()
+
+
+**Code to reproduce the bug**
+Any code that can be used to reproduce the bug, wrapped in tags:
+
+```cpp
+printf("hello world!")
+```
+
+If the code is longer than 30 lines you can use a [GIST](https://gist.github.com).
+
+Thank you for your contribution!

--- a/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for peak-ai
+labels: feature request
+
+---
+
+**Is your feature request related to a problem? Please describe.**  
+A clear and concise description of what the problem is. What are the use cases of the feature to be added? 
+
+**Describe the solution you would like.**  
+A clear and concise description of what you want to happen.
+
+**Additional context**  
+Add any other information (including rationale, requirements, or references) about the feature request here.
+
+Thank you for your contribution!

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Description
+
+*Depends on:*
+- Links to any pull requests linked to this
+
+_Description of what this PR does. What have you added or changed, and why?_
+
+# Steps to test
+1.
+2.
+3.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+## Reporting a security vulnerability or feedback
+
+If you discover a potential security issue in this project we ask that you notify Peak AI Security directly via email to security@peak.ai. 
+Please do **not** create a public github issue.


### PR DESCRIPTION
# Description

Adding standard templates for PRs, Issues, Code of Conduct etc. so that they can be added to automatically added to or used as a template in any public repositories that do not have their own.

*Depends on:*
- Correct layout, file names etc. [as per documentation](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file)

_Description of what this PR does. What have you added or changed, and why?_
Adds new files:
- Code of Conduct ()
- Contribution Guidelines
- Pull Request Template
- Security Guidelines
- Issue Templates - Bugs and Feature Requests

# Steps to test
Switch to this branch and view the repository checking the following:
1. Correct filenames
2. Correct directory structures
3. Spelling and Grammar
4. Anything else you deem relevant